### PR TITLE
Switch shortname in RadarOption.xml

### DIFF
--- a/MultiRadar/RadarViewOptionData.cs
+++ b/MultiRadar/RadarViewOptionData.cs
@@ -32,6 +32,20 @@ namespace MultiRadar
                     return true;
             }
         }
+        public bool IsShortNameView(RadarZoomSelect mode)
+        {
+            switch (mode)
+            {
+                case RadarZoomSelect.mob:
+                    return voMob.shortName;
+                case RadarZoomSelect.hum:
+                    return voHum.shortName;
+                case RadarZoomSelect.id:
+                    return voId.shortName;
+                default:
+                    return true;
+            }
+        }
         public bool IsPositionView(RadarZoomSelect mode)
         {
             switch (mode)

--- a/MultiRadar/Structure/RadarViewType.cs
+++ b/MultiRadar/Structure/RadarViewType.cs
@@ -18,6 +18,7 @@ namespace MultiRadar.Structure
     public class ViewOption
     {
         public bool name;
+        public bool shortName = true;
         public bool positon;
         public bool hp;
         public bool job;

--- a/MultiRadar/WPF/RadarWindow/MainWindow.xaml.cs
+++ b/MultiRadar/WPF/RadarWindow/MainWindow.xaml.cs
@@ -347,7 +347,14 @@ namespace Wpf.RadarWindow
                 bool flag = isFlag(mob.ID);
                 int hpPar = (mob.CurrentHP * 100 / mob.MaxHP);
                 bool shortName = true;
-                if (model.SelectChecked) { shortName = false; }
+                if (model.SelectChecked)
+                {
+                    shortName = false;
+                }
+                else if (!RadardataInstance.viewOptionData.IsShortNameView(RadarViewOrder.radarZoomSelect))
+                {
+                    shortName = false;
+                }
 
                 Rect rect = RadarViewOrder.MobRect(RadarViewOrder.myData.PosX, RadarViewOrder.myData.PosY, mob.PosX, mob.PosY);
                 if (mob.ID != RadarViewOrder.myData.ID)


### PR DESCRIPTION
フルネームで利用したかったため、短縮名を使うか設定ファイル(RadarOption.xml)で切り替えられるようにしました。

```
<mob>
  <name>true</name>
  <shortName>false</shortName>
  ....
```

<shortName>タグが無い場合、現状と変わらぬように初期値をshortName=trueとしてあります。